### PR TITLE
Add minimal React/FastAPI chat demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# aichat
+# ChatBot Demo
+
+Simple browser-based AI chat built with React and FastAPI.
+
+## Development
+
+```bash
+# install front-end deps and start Vite dev server
+cd frontend && pnpm install && pnpm dev
+```
+
+```bash
+# in another terminal run backend
+uvicorn backend.main:app --reload
+```
+
+Both servers use default ports (5173 and 8000).

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,46 @@
+# FastAPI server providing /chat endpoint
+# Requires OPENAI_API_KEY environment variable
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from typing import List, Dict
+import openai
+import os
+
+# Set API key from env
+openai.api_key = os.getenv('OPENAI_API_KEY')
+
+app = FastAPI()
+
+# Allow local frontend to talk to API
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=['http://localhost:5173'],
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+class ChatRequest(BaseModel):
+    messages: List[Dict[str, str]]
+    model: str
+
+@app.post('/chat')
+async def chat(req: ChatRequest):
+    """Stream assistant replies from OpenAI"""
+    # openai API call with streaming
+
+    async def generator():
+        response = await openai.ChatCompletion.acreate(
+            model=req.model,
+            messages=req.messages,
+            stream=True,
+        )
+        async for chunk in response:
+            delta = chunk.choices[0].delta
+            content = delta.get('content')
+            if content:
+                yield content
+    # Stream chunks back to the client as plain text
+
+    return StreamingResponse(generator(), media_type='text/plain')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.101.0
+uvicorn==0.23.2
+openai==0.27.8
+python-dotenv==1.0.0

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ChatBot</title>
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body class="bg-gradient-to-b from-sky-900 to-slate-900 min-h-screen">
+    <div id="root" class="flex justify-center"></div>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "chatbot-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "swr": "^2.2.0",
+    "lucide-react": "^0.292.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.27",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.0.4",
+    "vite": "^4.3.9"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,15 @@
+// Layout container
+
+import Chat from './Chat'
+import Header from './Header'
+import InputBar from './InputBar'
+
+export default function App() {
+  return (
+    <div className="w-full max-w-3xl flex flex-col min-h-screen">
+      <Header />
+      <Chat className="flex-1 overflow-y-auto" />
+      <InputBar />
+    </div>
+  )
+}

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -1,0 +1,23 @@
+// Scrollable list of messages
+
+import { useRef, useEffect } from 'react'
+import { useChat } from './ChatContext'
+import MessageBubble from './MessageBubble'
+
+export default function Chat({ className = '' }: { className?: string }) {
+  const { messages } = useChat()
+  const endRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  return (
+    <div className={`p-4 space-y-4 ${className}`}>
+      {messages.map((m, i) => (
+        <MessageBubble key={i} message={m} />
+      ))}
+      <div ref={endRef} />
+    </div>
+  )
+}

--- a/frontend/src/ChatContext.tsx
+++ b/frontend/src/ChatContext.tsx
@@ -1,0 +1,70 @@
+// Chat context holds messages and exposes send/clear functions
+import { createContext, useContext, useEffect, useState } from 'react'
+import useSWR from 'swr'
+
+export interface Message {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+interface ChatState {
+  messages: Message[]
+  model: string
+  setModel: (m: string) => void
+  sendMessage: (content: string) => Promise<void>
+  clear: () => void
+}
+
+const ChatContext = createContext<ChatState>(null as any)
+const STORAGE_PREFIX = 'chat-history-'
+
+export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [model, setModel] = useState('o3 mini')
+  // Load history from localStorage
+  const { data: messages = [], mutate } = useSWR<Message[]>(model, () => {
+    if (typeof window === 'undefined') return []
+    const raw = localStorage.getItem(STORAGE_PREFIX + model)
+    return raw ? JSON.parse(raw) : []
+  })
+
+  // Persist history when messages change
+  useEffect(() => {
+    localStorage.setItem(STORAGE_PREFIX + model, JSON.stringify(messages))
+  }, [messages, model])
+
+  // Send user message then stream assistant reply
+  const sendMessage = async (content: string) => {
+    const newList = [...messages, { role: 'user' as const, content }]
+    mutate(newList, false)
+    const res = await fetch('http://localhost:8000/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: newList, model })
+    })
+    const reader = res.body?.getReader()
+    if (!reader) return
+    const decoder = new TextDecoder('utf-8')
+    let assistant = { role: 'assistant' as const, content: '' }
+    mutate([...newList, assistant], false)
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      assistant.content += decoder.decode(value)
+      mutate([...newList, { ...assistant }], false)
+    }
+    mutate([...newList, assistant], true)
+  }
+
+  const clear = () => {
+    mutate([], false)
+    localStorage.removeItem(STORAGE_PREFIX + model)
+  }
+
+  return (
+    <ChatContext.Provider value={{ messages, model, setModel, sendMessage, clear }}>
+      {children}
+    </ChatContext.Provider>
+  )
+}
+
+export const useChat = () => useContext(ChatContext)

--- a/frontend/src/Header.tsx
+++ b/frontend/src/Header.tsx
@@ -1,0 +1,25 @@
+// Top bar with title, model picker and clear button
+
+import { useChat } from './ChatContext'
+
+const models = ['o3 mini', 'gpt-3.5-turbo']
+
+export default function Header() {
+  const { model, setModel, clear } = useChat()
+  return (
+    <header className="bg-slate-800 text-white flex items-center justify-between px-4 py-2">
+      <h1 className="font-bold text-lg">ChatBot</h1>
+      <div className="flex items-center gap-2">
+        <select
+          value={model}
+          onChange={e => setModel(e.target.value)}
+          className="bg-slate-700 text-sm px-2 py-1 rounded">
+          {models.map(m => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+        </select>
+      </div>
+      <button onClick={clear} className="text-sm hover:underline">Clear</button>
+    </header>
+  )
+}

--- a/frontend/src/InputBar.tsx
+++ b/frontend/src/InputBar.tsx
@@ -1,0 +1,53 @@
+// Expanding text input with send button
+
+import { useState, useRef } from 'react'
+import { useChat } from './ChatContext'
+import { SendHorizonal } from 'lucide-react'
+
+export default function InputBar() {
+  const { sendMessage } = useChat()
+  const [text, setText] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const resize = () => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = Math.min(el.scrollHeight, 24 * 6) + 'px'
+  }
+
+  const handleSend = () => {
+    if (!text.trim()) return
+    sendMessage(text.trim())
+    setText('')
+    resize()
+  }
+  // Enter submits, Shift+Enter adds newline
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  return (
+    <div className="p-4 border-t border-slate-300 flex items-end gap-2">
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={e => { setText(e.target.value); resize() }}
+        onInput={resize}
+        onKeyDown={handleKeyDown}
+        rows={1}
+        placeholder="Type a message..."
+        className="flex-1 resize-none rounded border border-slate-300 p-2 text-sm focus:outline-none focus:ring"
+      />
+      <button
+        onClick={handleSend}
+        className="p-2 bg-slate-800 text-white rounded hover:bg-slate-700">
+        <SendHorizonal className="w-5 h-5" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/MessageBubble.tsx
+++ b/frontend/src/MessageBubble.tsx
@@ -1,0 +1,17 @@
+// Chat message bubble with avatar
+
+import { Message } from './ChatContext'
+import { Bot, User } from 'lucide-react'
+
+export default function MessageBubble({ message }: { message: Message }) {
+  const isUser = message.role === 'user'
+  return (
+    <div className={`flex ${isUser ? 'justify-start' : 'justify-end'}`}>
+      {isUser && <User className="w-6 h-6 text-white mr-2 shrink-0" />}
+      <div className={`px-3 py-2 rounded-lg max-w-prose whitespace-pre-wrap ${isUser ? 'bg-blue-200' : 'bg-white'}`}>
+        {message.content}
+      </div>
+      {!isUser && <Bot className="w-6 h-6 text-gray-700 ml-2 shrink-0" />}
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply text-gray-900;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,15 @@
+// Entrypoint mounting React app
+
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+import { ChatProvider } from './ChatContext'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ChatProvider>
+      <App />
+    </ChatProvider>
+  </React.StrictMode>
+)

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss'
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- create React 18 + Vite frontend with Tailwind
- add chat context and components
- implement FastAPI backend streaming OpenAI replies
- document dev setup with pnpm and uvicorn

## Testing
- `pnpm --version`
- `python3 -m uvicorn --version` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_6841970afed8832c9443a7b4527d90a3