### PR TITLE
Add API key input field

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 # FastAPI server providing /chat endpoint
 # Requires OPENAI_API_KEY environment variable
-from fastapi import FastAPI
+from fastapi import FastAPI, Header
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -8,8 +8,8 @@ from typing import List, Dict
 import openai
 import os
 
-# Set API key from env
-openai.api_key = os.getenv('OPENAI_API_KEY')
+# Default API key from environment
+DEFAULT_API_KEY = os.getenv('OPENAI_API_KEY')
 
 app = FastAPI()
 
@@ -26,7 +26,7 @@ class ChatRequest(BaseModel):
     model: str
 
 @app.post('/chat')
-async def chat(req: ChatRequest):
+async def chat(req: ChatRequest, openai_api_key: str | None = Header(default=None)):
     """Stream assistant replies from OpenAI"""
     # openai API call with streaming
 
@@ -35,6 +35,7 @@ async def chat(req: ChatRequest):
             model=req.model,
             messages=req.messages,
             stream=True,
+            api_key=openai_api_key or DEFAULT_API_KEY,
         )
         async for chunk in response:
             delta = chunk.choices[0].delta

--- a/frontend/src/Header.tsx
+++ b/frontend/src/Header.tsx
@@ -5,11 +5,18 @@ import { useChat } from './ChatContext'
 const models = ['o3 mini', 'gpt-3.5-turbo']
 
 export default function Header() {
-  const { model, setModel, clear } = useChat()
+  const { model, setModel, apiKey, setApiKey, clear } = useChat()
   return (
     <header className="bg-slate-800 text-white flex items-center justify-between px-4 py-2">
       <h1 className="font-bold text-lg">ChatBot</h1>
       <div className="flex items-center gap-2">
+        <input
+          type="password"
+          value={apiKey}
+          onChange={e => setApiKey(e.target.value)}
+          placeholder="OpenAI API key"
+          className="bg-slate-700 text-sm px-2 py-1 rounded"
+        />
         <select
           value={model}
           onChange={e => setModel(e.target.value)}
@@ -18,8 +25,9 @@ export default function Header() {
             <option key={m} value={m}>{m}</option>
           ))}
         </select>
+        <button onClick={clear} className="text-sm hover:underline">Clear</button>
       </div>
-      <button onClick={clear} className="text-sm hover:underline">Clear</button>
     </header>
   )
 }
+


### PR DESCRIPTION
## Summary
- support sending per-request API key on the backend
- persist OpenAI API key on the frontend and send with chat requests
- add input for the API key in the header

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Freact-dom: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684199f4938c832cb42b630fe3024fab